### PR TITLE
GET endpoint to fetch all projects of a mentor

### DIFF
--- a/controllers/mentor.go
+++ b/controllers/mentor.go
@@ -5,6 +5,8 @@ import (
 
 	"kwoc20-backend/models"
 	"kwoc20-backend/utils"
+	"encoding/json"
+	"github.com/gorilla/mux"
 )
 
 // After Being checked by LoginRequired Middleware
@@ -47,3 +49,30 @@ func MentorDashboard(req map[string]interface{}, r *http.Request) (interface{}, 
 	return res, 200
 }
 
+func MentorProjects(w http.ResponseWriter, r *http.Request)() {
+
+	db := utils.GetDB()
+	defer db.Close()
+
+	vars := mux.Vars(r)	
+	mentor_username := vars["MENTOR_USERNAME"]
+
+	var mentor models.Mentor 
+	db.Where("username = ?", mentor_username).First(&mentor)
+	mentor_id := mentor.ID
+
+	if mentor_id == 0 {
+		w.WriteHeader(500)
+		return
+	}
+	var projects []models.Project
+	db.Where("mentor_id = ?", mentor_id).Find(&projects)
+	projects_json, err := json.Marshal(projects)
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(projects_json)
+}

--- a/routes/mentor.go
+++ b/routes/mentor.go
@@ -12,6 +12,6 @@ import (
 // Discuss and add 2 middlewares - JWT Required, JSON Marshalling
 func RegisterMentor(r *mux.Router) {
 	r.HandleFunc("/form", utils.LoginRequired(utils.JsonIO(controllers.MentorReg))).Methods("POST")
-
+	r.HandleFunc("/{MENTOR_USERNAME}/projects", controllers.MentorProjects).Methods("GET")
 }
 


### PR DESCRIPTION
Closes #31 

/MENTOR_USERNAME/projects route added to routes/mentor.go and the function MentorProjects is in controllers/mentor.go. I have tested this on dummy data.