### PR TITLE
Added a `DEV` environment variable to use local .db file

### DIFF
--- a/utils/database.go
+++ b/utils/database.go
@@ -9,31 +9,13 @@ import (
 
 	// _ "github.com/jinzhu/gorm/dialects/mysql" // MySQL Dialect
 	_ "github.com/jinzhu/gorm/dialects/postgres"
-	// _ "github.com/jinzhu/gorm/dialects/sqlite" // sqlite for dev
+	_ "github.com/jinzhu/gorm/dialects/sqlite" // sqlite for dev
 )
 
 // InitialMigration Initialize migration
 func InitialMigration() {
-	DatabaseUsername := os.Getenv("DATABASE_USERNAME")
-	DatabasePassword := os.Getenv("DATABASE_PASSWORD")
-	DatabaseName := os.Getenv("DATABASE_NAME")
-	DatabaseHost := os.Getenv("DATABASE_HOST")
-	DatabasePort := os.Getenv("DATABASE_PORT")
-
-	newURI := "host=" + DatabaseHost + " port=" + DatabasePort + " user=" + DatabaseUsername + " dbname=" + DatabaseName + " sslmode=disable password=" + DatabasePassword
-	db, err := gorm.Open("postgres", newURI)
-	if err != nil {
-		log.Err(err).Msg("Database Error")
-		panic(err)
-	}
-
-	// // temporary SQLite for ease of development
-	// db, err := gorm.Open("sqlite3", "kwoc.db")
-	// if err != nil {
-	// 	log.Err(err).Msg("Database Error")
-	// 	panic("failed to connect database")
-	// }
-	// defer db.Close()
+	db := GetDB()
+	defer db.Close()
 
 	db.AutoMigrate(&models.Mentor{})
 	db.AutoMigrate(&models.Student{})
@@ -44,26 +26,33 @@ func InitialMigration() {
 
 // GetDB Get Database
 func GetDB() *gorm.DB {
-	DatabaseUsername := os.Getenv("DATABASE_USERNAME")
-	DatabasePassword := os.Getenv("DATABASE_PASSWORD")
-	DatabaseName := os.Getenv("DATABASE_NAME")
-	DatabaseHost := os.Getenv("DATABASE_HOST")
-	DatabasePort := os.Getenv("DATABASE_PORT")
+	isDev := os.Getenv("DEV") == "true"
 
-	newURI := "host=" + DatabaseHost + " port=" + DatabasePort + " user=" + DatabaseUsername + " dbname=" + DatabaseName + " sslmode=disable password=" + DatabasePassword
-	db, err := gorm.Open("postgres", newURI)
-	if err != nil {
-		log.Err(err).Msg("Database Error")
-		panic(err)
+	if !isDev {
+		DatabaseUsername := os.Getenv("DATABASE_USERNAME")
+		DatabasePassword := os.Getenv("DATABASE_PASSWORD")
+		DatabaseName := os.Getenv("DATABASE_NAME")
+		DatabaseHost := os.Getenv("DATABASE_HOST")
+		DatabasePort := os.Getenv("DATABASE_PORT")
+
+		newURI := "host=" + DatabaseHost + " port=" + DatabasePort + " user=" + DatabaseUsername + " dbname=" + DatabaseName + " sslmode=disable password=" + DatabasePassword
+		db, err := gorm.Open("postgres", newURI)
+
+		if err != nil {
+			log.Err(err).Msg("Database Error")
+			panic(err)
+		}
+
+		return db
+	} else {
+		// SQLite database for local development
+
+		db, err := gorm.Open("sqlite3", "devDB.db")
+		if err != nil {
+			log.Err(err).Msg("Database Error")
+			panic(err)
+		}
+
+		return db
 	}
-	// TODO : DB close issue
-
-	// // temporary SQLite for ease of development
-	// db, err := gorm.Open("sqlite3", "kwoc.db")
-	// if err != nil {
-	// 	log.Err(err).Msg("Database Error")
-	// 	panic(err)
-	// }
-
-	return db
 }

--- a/utils/database.go
+++ b/utils/database.go
@@ -28,6 +28,9 @@ func InitialMigration() {
 func GetDB() *gorm.DB {
 	isDev := os.Getenv("DEV") == "true"
 
+	var dbDialect string
+	var dbURI string
+
 	if !isDev {
 		DatabaseUsername := os.Getenv("DATABASE_USERNAME")
 		DatabasePassword := os.Getenv("DATABASE_PASSWORD")
@@ -35,24 +38,21 @@ func GetDB() *gorm.DB {
 		DatabaseHost := os.Getenv("DATABASE_HOST")
 		DatabasePort := os.Getenv("DATABASE_PORT")
 
-		newURI := "host=" + DatabaseHost + " port=" + DatabasePort + " user=" + DatabaseUsername + " dbname=" + DatabaseName + " sslmode=disable password=" + DatabasePassword
-		db, err := gorm.Open("postgres", newURI)
+		dbDialect = "postgres"
+		dbURI = "host=" + DatabaseHost + " port=" + DatabasePort + " user=" + DatabaseUsername + " dbname=" + DatabaseName + " sslmode=disable password=" + DatabasePassword
 
-		if err != nil {
-			log.Err(err).Msg("Database Error")
-			panic(err)
-		}
-
-		return db
 	} else {
 		// SQLite database for local development
-
-		db, err := gorm.Open("sqlite3", "devDB.db")
-		if err != nil {
-			log.Err(err).Msg("Database Error")
-			panic(err)
-		}
-
-		return db
+		dbDialect = "sqlite3"
+		dbURI = "devDB.db"
 	}
+
+	db, err := gorm.Open(dbDialect, dbURI)
+
+	if err != nil {
+		log.Err(err).Msg("Database Error")
+		panic(err)
+	}
+
+	return db
 }


### PR DESCRIPTION
### Changes
- Added an environment `DEV` (boolean). Setting this variable to `true` will use a local `devDB.db` sqlite3 database file instead of the online Postgres db.
- Refactored `InitialMigration()` to use the `GetDB()` method (removed duplicated code)
- Added a `defer db.Close()` to `IntialMigration()`