### PR TITLE
[v2] Added support for loading .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ./backend
+.env
+*.db

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Libraries Used](#libraries-used)
   - [File Structure](#file-structure)
   - [Endpoints](#endpoints)
+  - [Command-Line Arguments](#command-line-arguments)
   - [Environment Variables](#environment-variables)
   - [Github OAuth](#github-oauth)
 
@@ -60,6 +61,10 @@
 - Do not keep many functions in utils, if they can be grouped in a package, then do so.
 
 ### Endpoints
+### Command-Line Arguments
+The following command-line arguments are accepted by `cmd/backend.go`. `--argument=value`, `--argument value`, `-argument=value`, and `-argument value` are all acceptable formats to pass a value to the command-line argument.
+- `envFile`: A file to load environment variables from. (Default: `.env`)
+
 ### Environment Variables
 ### Github OAuth
 

--- a/cmd/backend.go
+++ b/cmd/backend.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"kwoc-backend/server"
 	"net/http"
 	"os"
@@ -14,18 +15,22 @@ import (
 )
 
 func main() {
+	// Parse command-line arguments
+	envFile := flag.String("envFile", ".env", "A file to load environment variables from.")
+	flag.Parse()
+
 	// Logger options ( using zerrolog )
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	// Load environment variables via .env files
-	log.Info().Msg("Attempting to load .env file.")
-	dotenv_err := godotenv.Load()
+	log.Info().Msgf("Attempting to load environment variables from %s.", *envFile)
+	dotenv_err := godotenv.Load(*envFile)
 
 	if dotenv_err != nil {
-		log.Warn().Msg("Failed to load .env file.")
+		log.Warn().Msgf("Failed to load environment variables from %s.", *envFile)
 	} else {
-		log.Info().Msg("Successfully loaded .env file.")
+		log.Info().Msgf("Successfully loaded environment variables from %s.", *envFile)
 	}
 
 	log.Info().Msg("Creating mux router")

--- a/cmd/backend.go
+++ b/cmd/backend.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -16,6 +17,16 @@ func main() {
 	// Logger options ( using zerrolog )
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	// Load environment variables via .env files
+	log.Info().Msg("Attempting to load .env file.")
+	dotenv_err := godotenv.Load()
+
+	if dotenv_err != nil {
+		log.Warn().Msg("Failed to load .env file.")
+	} else {
+		log.Info().Msg("Successfully loaded .env file.")
+	}
 
 	log.Info().Msg("Creating mux router")
 	router := server.NewRouter()

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=


### PR DESCRIPTION
Closes #102 

#### Changes
- Added support for loading .env files using `godotenv` library.
- Gitignored `.env` and `*.db` files.