### PR TITLE
Endpoints and oauth for organisers

### DIFF
--- a/controllers/project_fetch.go
+++ b/controllers/project_fetch.go
@@ -169,6 +169,12 @@ func FetchProjectDetails(w http.ResponseWriter, r *http.Request) {
 func OrgFetchAllProjectDetails(w http.ResponseWriter, r *http.Request) {
 	app := r.Context().Value(middleware.APP_CTX_KEY).(*middleware.App)
 	db := app.Db
+	username := r.Context().Value(middleware.LOGIN_CTX_USERNAME_KEY).(string)
+
+	if !strings.Contains(username, "organiser!") {
+		utils.LogErrAndRespond(r, w, nil, fmt.Sprintf("Error '%s' is not an organiser", username), 400)
+		return
+	}
 
 	var projects []models.Project
 
@@ -176,7 +182,7 @@ func OrgFetchAllProjectDetails(w http.ResponseWriter, r *http.Request) {
 		Table("projects").
 		Preload("Mentor").
 		Preload("SecondaryMentor").
-		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "readme_link", "mentor_id", "secondary_mentor_id", "project_status", "status_remark").
+		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "readme_link", "mentor_id", "secondary_mentor_id", "project_status", "status_remark", "pull_count").
 		Find(&projects)
 
 	if tx.Error != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -129,6 +129,12 @@ func getRoutes(app *middleware.App) []Route {
 			"/project/",
 			middleware.WrapApp(app, controllers.FetchAllProjects),
 			false,
+		}, {
+			"Get All Projects For Admins",
+			"GET",
+			"/project/all",
+			middleware.WithLogin(middleware.WrapApp(app, controllers.OrgFetchAllProjectDetails)),
+			false,
 		},
 		{
 			"Update Project Details",

--- a/utils/oauth.go
+++ b/utils/oauth.go
@@ -133,12 +133,17 @@ func GetOauthUserInfo(accessToken string) (*GHUserInfo, error) {
 func CheckUserOrgs(accessToken string, username string) bool {
 
 	client := http.Client{}
-	url := fmt.Sprintf("https://api.github.com/orgs/kossiitkgp/teams/Executives/memberships/%s", username)
+	url := fmt.Sprintf("https://api.github.com/orgs/kossiitkgp/teams/executies/memberships/%s", username)
 	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Add(
+		"Authorization",
+		fmt.Sprintf("Bearer %s", accessToken),
+	)
 	resp, _ := client.Do(req)
 
-	LogWarn(resp.Request, "Error getting orgs")
-
-	return true
+	if resp.StatusCode == 200 {
+		return true
+	} else {
+		return false
+	}
 }

--- a/utils/oauth.go
+++ b/utils/oauth.go
@@ -129,3 +129,16 @@ func GetOauthUserInfo(accessToken string) (*GHUserInfo, error) {
 
 	return &userInfo, nil
 }
+
+func CheckUserOrgs(accessToken string, username string) bool {
+
+	client := http.Client{}
+	url := fmt.Sprintf("https://api.github.com/orgs/kossiitkgp/teams/Executives/memberships/%s", username)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, _ := client.Do(req)
+
+	LogWarn(resp.Request, "Error getting orgs")
+
+	return true
+}


### PR DESCRIPTION
## Features

1) Organisers have a special prrefix added to their username present in  the jwt. We check this during request to make sure user is in fact an organiser.

2) Added a new endpoint which fetches all projects irrespective of approval status

3) Organisers are the members of the [Executies](https://github.com/orgs/kossiitkgp/teams/executies) team of [kossiitkgp](https://github.com/org/kossiitkgp)