### PR TITLE
Remove unused readme_link field from projects model

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The `models/` directory contains database models for the KWoC database tables. (
   - `description` (string): Description for the project.
   - `tags` (string): A list of tags for the project.
   - `comm_channel` (string): A link to the project's official communication channel.
-  - `readme_link` (string): A link to the project's README file.
+ 
   - `project_status` (bool): Whether the project is approved.
   - `status_remark` (string): Message that states the reason for rejection/suggested changes for project approval
   - `last_pull_time` (int64): The timestamp of merging the last tracked pull request (for statistics).

--- a/controllers/mentor.go
+++ b/controllers/mentor.go
@@ -29,7 +29,7 @@ type ProjectInfo struct {
 	Name          string   `json:"name"`
 	Description   string   `json:"description"`
 	RepoLink      string   `json:"repo_link"`
-	ReadmeLink    string   `json:"readme_link"`
+	
 	Tags          []string `json:"tags"`
 	ProjectStatus bool     `json:"project_status"`
 	StatusRemark  string   `json:"status_remark"`
@@ -169,7 +169,7 @@ func CreateMentorDashboard(mentor models.Mentor, db *gorm.DB) MentorDashboard {
 			Name:          project.Name,
 			Description:   project.Description,
 			RepoLink:      project.RepoLink,
-			ReadmeLink:    project.ReadmeLink,
+			
 			Tags:          tags,
 			ProjectStatus: project.ProjectStatus,
 			StatusRemark:  project.StatusRemark,

--- a/controllers/project_fetch.go
+++ b/controllers/project_fetch.go
@@ -25,7 +25,6 @@ type Project struct {
 	Tags            []string `json:"tags"`
 	RepoLink        string   `json:"repo_link"`
 	CommChannel     string   `json:"comm_channel"`
-	ReadmeLink      string   `json:"readme_link"`
 	Mentor          Mentor   `json:"mentor"`
 	SecondaryMentor Mentor   `json:"secondary_mentor"`
 }
@@ -49,7 +48,6 @@ func newProject(dbProject *models.Project) Project {
 		Tags:            tags,
 		RepoLink:        dbProject.RepoLink,
 		CommChannel:     dbProject.CommChannel,
-		ReadmeLink:      dbProject.ReadmeLink,
 		Mentor:          newMentor(&dbProject.Mentor),
 		SecondaryMentor: newMentor(&dbProject.SecondaryMentor),
 	}
@@ -75,7 +73,7 @@ func FetchAllProjects(w http.ResponseWriter, r *http.Request) {
 		Preload("Mentor").
 		Preload("SecondaryMentor").
 		Where("project_status = ?", true).
-		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "readme_link", "mentor_id", "secondary_mentor_id").
+		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "mentor_id", "secondary_mentor_id").
 		Find(&projects)
 
 	if tx.Error != nil {
@@ -135,7 +133,7 @@ func FetchProjectDetails(w http.ResponseWriter, r *http.Request) {
 		Preload("Mentor").
 		Preload("SecondaryMentor").
 		Where("id = ?", project_id).
-		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "readme_link", "mentor_id", "secondary_mentor_id").
+		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "mentor_id", "secondary_mentor_id").
 		First(&project)
 
 	if tx.Error != nil && tx.Error != gorm.ErrRecordNotFound {

--- a/controllers/project_fetch_unapproved.go
+++ b/controllers/project_fetch_unapproved.go
@@ -34,7 +34,7 @@ func FetchUnapprovedProjects(w http.ResponseWriter, r *http.Request) {
 		Preload("Mentor").
 		Preload("SecondaryMentor").
 		Where("project_status = ?", false).
-		Select("id", "name", "description", "tags", "repo_link", "comm_channel", "readme_link", "mentor_id", "secondary_mentor_id").
+		Select("id", "name", "description", "tags", "repo_link", "comm_channel",  "mentor_id", "secondary_mentor_id").
 		Find(&projects)
 
 	if tx.Error != nil {

--- a/controllers/project_reg.go
+++ b/controllers/project_reg.go
@@ -27,8 +27,6 @@ type RegisterProjectReqFields struct {
 	RepoLink string `json:"repo_link"`
 	// Link to a communication channel/platform
 	CommChannel string `json:"comm_channel"`
-	// Link to the project's README file
-	ReadmeLink string `json:"readme_link"`
 }
 
 // RegisterProject godoc
@@ -154,7 +152,6 @@ func RegisterProject(w http.ResponseWriter, r *http.Request) {
 		Tags:            strings.Join(reqFields.Tags, ","),
 		RepoLink:        reqFields.RepoLink,
 		CommChannel:     reqFields.CommChannel,
-		ReadmeLink:      reqFields.ReadmeLink,
 		Mentor:          mentor,
 		SecondaryMentor: secondaryMentor,
 	})

--- a/controllers/project_update.go
+++ b/controllers/project_update.go
@@ -30,7 +30,7 @@ type UpdateProjectReqFields struct {
 	// Link to a communication channel/platform
 	CommChannel string `json:"comm_channel"`
 	// Link to the project's README file
-	ReadmeLink string `json:"readme_link"`
+	
 }
 
 // UpdateProject godoc
@@ -144,7 +144,7 @@ func UpdateProject(w http.ResponseWriter, r *http.Request) {
 		Tags:            strings.Join(reqFields.Tags, ","),
 		RepoLink:        reqFields.RepoLink,
 		CommChannel:     reqFields.CommChannel,
-		ReadmeLink:      reqFields.ReadmeLink,
+		
 		SecondaryMentor: secondaryMentor,
 	}
 

--- a/models/projects.go
+++ b/models/projects.go
@@ -13,7 +13,7 @@ type Project struct {
 	Tags          string `gorm:"column:tags"`
 	RepoLink      string `gorm:"column:repo_link"`
 	CommChannel   string `gorm:"column:comm_channel"`
-	// remove unused readme_link field from projects model
+	
 	ProjectStatus bool   `gorm:"default:false;column:project_status"`
 	StatusRemark  string `gorm:"default:null;column:status_remark"`
 

--- a/models/projects.go
+++ b/models/projects.go
@@ -13,7 +13,7 @@ type Project struct {
 	Tags          string `gorm:"column:tags"`
 	RepoLink      string `gorm:"column:repo_link"`
 	CommChannel   string `gorm:"column:comm_channel"`
-	ReadmeLink    string `gorm:"column:readme_link"`
+	// remove unused readme_link field from projects model
 	ProjectStatus bool   `gorm:"default:false;column:project_status"`
 	StatusRemark  string `gorm:"default:null;column:status_remark"`
 

--- a/tests/mentor_test.go
+++ b/tests/mentor_test.go
@@ -282,7 +282,7 @@ func TestMentorDashboardOK(t *testing.T) {
 			Name:          p.Name,
 			Description:   p.Description,
 			RepoLink:      p.RepoLink,
-			ReadmeLink:    p.ReadmeLink,
+			
 			Tags:          tags,
 			ProjectStatus: p.ProjectStatus,
 			StatusRemark:  p.StatusRemark,

--- a/tests/project_fetch_test.go
+++ b/tests/project_fetch_test.go
@@ -53,7 +53,7 @@ func generateTestProjects(numProjects int, randomizeProjectStatus bool, defaultP
 				Tags:          fmt.Sprintf("next-gen, javascript, framework, %dth iteration", rand.Int()),
 				RepoLink:      "https://xkcd.com/927/",
 				CommChannel:   fmt.Sprintf("https://link%d", rand.Int()),
-				ReadmeLink:    fmt.Sprintf("https://readme%d", rand.Int()),
+				
 				ProjectStatus: projectStatus,
 				StatusRemark:  fmt.Sprintf("Status remark %d", rand.Int()),
 
@@ -75,7 +75,7 @@ func areProjectsEquivalent(proj1 *controllers.Project, proj2 *models.Project) bo
 		strings.Join(proj1.Tags, ",") == proj2.Tags &&
 		proj1.RepoLink == proj2.RepoLink &&
 		proj1.CommChannel == proj2.CommChannel &&
-		proj1.ReadmeLink == proj2.ReadmeLink
+		
 }
 
 func TestFetchAllProjects(t *testing.T) {

--- a/tests/project_reg_test.go
+++ b/tests/project_reg_test.go
@@ -24,7 +24,7 @@ func createTestProjectRegFields(mentorUsername string, secondaryMentorUsername s
 		SecondaryMentorUsername: secondaryMentorUsername,
 		RepoLink:                "https://xkcd.com/927/",
 		CommChannel:             "comm-channel",
-		ReadmeLink:              "readme",
+		
 	}
 }
 

--- a/tests/project_update_test.go
+++ b/tests/project_update_test.go
@@ -86,7 +86,7 @@ func tProjectUpdateExistent(db *gorm.DB, testUsername string, testJwt string, t 
 		Tags:          strings.Join(projRegFields.Tags, ","),
 		RepoLink:      projRegFields.RepoLink,
 		CommChannel:   projRegFields.CommChannel,
-		ReadmeLink:    projRegFields.ReadmeLink,
+		
 		ProjectStatus: true,
 
 		Mentor: models.Mentor{
@@ -107,7 +107,7 @@ func tProjectUpdateExistent(db *gorm.DB, testUsername string, testJwt string, t 
 		MentorUsername: testUsername,
 		RepoLink:       "http://NewRepoLink",
 		CommChannel:    "totallynewcomchannel",
-		ReadmeLink:     "http://NewRepoLink/README",
+		
 	}
 
 	// Test with a valid new secondary mentor
@@ -150,9 +150,7 @@ func tProjectUpdateExistent(db *gorm.DB, testUsername string, testJwt string, t 
 		t.Errorf("Project CommChannel field did not get updated\n Expected: `%s`. Received: `%s`", projUpdateFields.CommChannel, updatedProj.CommChannel)
 	}
 
-	if updatedProj.ReadmeLink != projUpdateFields.ReadmeLink {
-		t.Errorf("Project ReadmeLink field did not get updated\n Expected: `%s`. Received: `%s`", projUpdateFields.ReadmeLink, updatedProj.ReadmeLink)
-	}
+	
 
 	if updatedProj.SecondaryMentor.Username != projUpdateFields.SecondaryMentorUsername {
 		t.Errorf("Project secondary mentor username did not get updated\n Expected: `%s`. Received: `%s`", projUpdateFields.SecondaryMentorUsername, updatedProj.SecondaryMentor.Username)


### PR DESCRIPTION
I've successfully consolidated all changes into this single PR as requested.

Changes included:
-  models/projects.go (removed readme_link field)
-  controllers/project_fetch.go (removed readme_link from struct and queries)
-  controllers/project_reg.go (removed readme_link from registration)

All related changes for this issue  are now in one PR with 3 commits.
Closed PR #199 and PR #200 per your feedback.